### PR TITLE
Fixed a bug, where bottom bar loses state when you rotate the screen.

### DIFF
--- a/android/src/main/java/com/inspiredandroid/linuxcommandbibliotheca/ui/composables/BottomBar.kt
+++ b/android/src/main/java/com/inspiredandroid/linuxcommandbibliotheca/ui/composables/BottomBar.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
@@ -41,7 +42,7 @@ fun BottomBar(navController: NavHostController) {
         Screen.Commands
     )
     // TODO: read current route from navcontroller
-    val selectedRoute = remember { mutableStateOf(Screen.Basics.route) }
+    val selectedRoute = rememberSaveable{ mutableStateOf(Screen.Basics.route) }
 
     BottomNavigation(backgroundColor = MaterialTheme.colors.surface) {
         items.forEach { screen ->


### PR DESCRIPTION
Fixed a bug. When you rotate the screen, the selected element at the bottom bar would reset. Because it used remember{} which loses data after configuration change. Change it to rememberSaveable{}, and now the bug is fixed.