### PR TITLE
Fix: Address Play Store warnings for edge-to-edge implementation

### DIFF
--- a/android/src/main/java/com/inspiredandroid/linuxcommandbibliotheca/MainActivity.kt
+++ b/android/src/main/java/com/inspiredandroid/linuxcommandbibliotheca/MainActivity.kt
@@ -65,7 +65,7 @@ class MainActivity : AppCompatActivity() {
     private val dataManager by inject<DataManager>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        enableEdgeToEdge(statusBarStyle = SystemBarStyle.dark(android.graphics.Color.TRANSPARENT))
+        enableEdgeToEdge(statusBarStyle = SystemBarStyle.dark(android.graphics.Color.TRANSPARENT), navigationBarStyle = SystemBarStyle.dark(android.graphics.Color.TRANSPARENT))
         super.onCreate(savedInstanceState)
 
         if (!hasDatabase(this) || !dataManager.isDatabaseUpToDate()) {


### PR DESCRIPTION
Modifies the enableEdgeToEdge() call in MainActivity to explicitly set the navigationBarStyle to transparent. This is intended to resolve Play Store warnings about the deprecated setNavigationBarColor API.

The app already targets SDK 35 and uses enableEdgeToEdge(), which should address the general warning about edge-to-edge display and the LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES warning by adhering to modern Android best practices.

Further review of the deprecated accompanist-systemuicontroller library is recommended as a follow-up action.