### PR TITLE
refined 2 `find` commands at the one-liners

### DIFF
--- a/assets/basics/oneliners.md
+++ b/assets/basics/oneliners.md
@@ -88,7 +88,7 @@
 ```[sort](/man/sort) file | [uniq](/man/uniq)```
 
 ## Find files by name
-```[find](/man/find) . -name "*.log"```
+```[find](/man/find) . -iname "*.log"```
 
 ## Find files larger than 100MB
 ```[find](/man/find) . -type f -size +100M```
@@ -268,7 +268,7 @@
 ```[ls](/man/ls) | [wc](/man/wc) -l```
 
 ## Find broken symlinks
-```[find](/man/find) . -type l -! -exec test -e {} \; -print```
+```[find](/man/find) . -xtype l```
 
 ## Quick HTTP server in Ruby
 ```[ruby](/man/ruby) -run -e httpd . -p 8000```


### PR DESCRIPTION
most importantly, i simplified the command to _"Find broken symlinks"_: no idea why it was made so complicated... beside that it launches an extra command for every link found, which results in higher load and much longer processing time. especially when scanning big file systems with many links, that makes quite a difference.

and while i'm at it, i also made the find command to _"Find files by name"_ case insensitive to be on the safe side.
...i know, for this example it is more or less irrelevant, but if users use the same command to find other files without even a glimpse at the manpage, it might become relevant.