### PR TITLE
TMUX: More ctrl + b prefix keys, separated by command type

### DIFF
--- a/assets/commands/tmux.md
+++ b/assets/commands/tmux.md
@@ -99,17 +99,36 @@ tmux is widely used for remote server administration, pair programming, and mana
 
 # KEY BINDINGS (after Ctrl-b)
 
+**?**: List all key bindings
+
+## Session Commands
+
 **d**: Detach from session
+**$**: Rename current session
+
+## Window Commands
+
+**,**: Rename current window
+**&**: Kill current window
 **c**: Create new window
 **n/p**: Next/previous window
 **0-9**: Switch to window number
+**l**: Move to previously selected window
+
+## Pane Commands
+
+**!**: Transform current pane into a new window
+**x**: Kill current pane
+**z**: Zoom pane (toggle)
 **"**: Split pane horizontally
 **%**: Split pane vertically
 **o**: Switch pane
-**x**: Kill pane
-**z**: Zoom pane (toggle)
+**Pg Up/Down/Left/Right**: Change to pane above, below, left, or right of current pane.
+**Space**: Arrange current window by one of seven pane layouts (see M-1 to M-7 in **?** command)
+
+
+**:**: Input a `tmux` parameter from within a session
 **[**: Enter copy mode
-**?**: List all key bindings
 
 # CONFIGURATION
 


### PR DESCRIPTION
Hello! Here it is. When it comes to the prefix keys, the "basics" documentation of the `tmux` command is already pretty complete. I realize now that one would probably just reference this basics document if they wanted to consult more in-depth documentation. Anyways, I took the liberty of:

1) Adding more commands to the ctrl + b  (focus on ones that felt frequently used)
2) Doing a bit of light organization for different command types
3) Added `-h` to the main commands

P.S.: If you don't want the subheaders I'll just get rid of them.
Closes #101