### PR TITLE
docs: fix typo quering -> querying

### DIFF
--- a/assets/commands/ytmdl.md
+++ b/assets/commands/ytmdl.md
@@ -37,7 +37,7 @@ Download music with automatic metadata tagging
 > Audio format (mp3, m4a, opus, etc.)
 
 **--skip-meta**
-> Skip quering metadata and downloading default one
+> Skip querying metadata and downloading default one
 
 **-q**, **--quiet**
 > Suppress output


### PR DESCRIPTION
One-word typo fix in `assets/commands/ytmdl.md:40`: "Skip quering metadata and downlo..." → `querying`.
